### PR TITLE
Rabbit timeout should be integer

### DIFF
--- a/Shuttle.Esb.RabbitMQ/RabbitMQQueue.cs
+++ b/Shuttle.Esb.RabbitMQ/RabbitMQQueue.cs
@@ -99,7 +99,7 @@ namespace Shuttle.Esb.RabbitMQ
 
 				if (transportMessage.HasExpiryDate())
 				{
-					var milliseconds = (transportMessage.ExpiryDate - DateTime.Now).TotalMilliseconds;
+					var milliseconds = (long) (transportMessage.ExpiryDate - DateTime.Now).TotalMilliseconds;
 
 					if (milliseconds < 1)
 					{


### PR DESCRIPTION
Hi,

I'm sorry, the fix from yesterday is wrong. I just realized that it works with Publish but does not work with Send (why is it different?). The timeout should be an integer (3*int.Maxvalue seems to work, so probabably "long") number.

Thanks,
Gábor