### PR TITLE
Channels belongs to connections, not to queues, using weak table to a…

### DIFF
--- a/Shuttle.Esb.RabbitMQ/Bootstrap.cs
+++ b/Shuttle.Esb.RabbitMQ/Bootstrap.cs
@@ -7,7 +7,7 @@ namespace Shuttle.Esb.RabbitMQ
     {
         public void Register(IComponentRegistry registry)
         {
-            Guard.AgainstNull(registry, "registry");
+            Guard.AgainstNull(registry, nameof(registry));
 
             if (!registry.IsRegistered<IRabbitMQConfiguration>())
             {

--- a/Shuttle.Esb.RabbitMQ/Channel.cs
+++ b/Shuttle.Esb.RabbitMQ/Channel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.InteropServices;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using RabbitMQ.Client.MessagePatterns;
@@ -6,7 +7,7 @@ using Shuttle.Core.Contract;
 
 namespace Shuttle.Esb.RabbitMQ
 {
-    internal class Channel : IDisposable
+    internal sealed class Channel : IDisposable
     {
         private readonly string _queue;
         private Subscription _subscription;
@@ -14,9 +15,9 @@ namespace Shuttle.Esb.RabbitMQ
 
         public Channel(IModel model, RabbitMQUriParser parser, IRabbitMQConfiguration configuration)
         {
-            Guard.AgainstNull(model, "model");
-            Guard.AgainstNull(parser, "parser");
-            Guard.AgainstNull(configuration, "configuration");
+            Guard.AgainstNull(model, nameof(model));
+            Guard.AgainstNull(parser, nameof(parser));
+            Guard.AgainstNull(configuration, nameof(configuration));
 
             Model = model;
 
@@ -56,12 +57,19 @@ namespace Shuttle.Esb.RabbitMQ
 
         public void Dispose()
         {
-            if (Model.IsOpen)
+            try
             {
-                Model.Close();
-            }
+                if (Model.IsOpen)
+                {
+                    Model.Close();
+                }
 
-            Model.Dispose();
+                Model.Dispose();
+            }
+            catch
+            {
+                // ignored
+            }
         }
     }
 }

--- a/Shuttle.Esb.RabbitMQ/RabbitMQQueueFactory.cs
+++ b/Shuttle.Esb.RabbitMQ/RabbitMQQueueFactory.cs
@@ -16,14 +16,14 @@ namespace Shuttle.Esb.RabbitMQ
 
         public IQueue Create(Uri uri)
         {
-            Guard.AgainstNull(uri, "uri");
+            Guard.AgainstNull(uri, nameof(uri));
 
             return new RabbitMQQueue(uri, Configuration);
         }
 
         public bool CanCreate(Uri uri)
         {
-            Guard.AgainstNull(uri, "uri");
+            Guard.AgainstNull(uri, nameof(uri));
 
             return Scheme.Equals(uri.Scheme, StringComparison.InvariantCultureIgnoreCase);
         }

--- a/Shuttle.Esb.RabbitMQ/RabbitMQUriParser.cs
+++ b/Shuttle.Esb.RabbitMQ/RabbitMQUriParser.cs
@@ -11,7 +11,7 @@ namespace Shuttle.Esb.RabbitMQ
 
         public RabbitMQUriParser(Uri uri)
         {
-            Guard.AgainstNull(uri, "uri");
+            Guard.AgainstNull(uri, nameof(uri));
 
             if (!uri.Scheme.Equals(Scheme, StringComparison.InvariantCultureIgnoreCase))
             {
@@ -74,6 +74,7 @@ namespace Shuttle.Esb.RabbitMQ
             SetDurability(queryString);
             SetPriority(queryString);
             SetPersistent(queryString);
+            SetName(queryString);
         }
 
         public Uri Uri { get; }
@@ -81,6 +82,7 @@ namespace Shuttle.Esb.RabbitMQ
         public bool Durable { get; private set; }
         public byte Priority { get; private set; }
         public bool Persistent { get; private set; }
+        public string Name { get; private set; }
 
         public int PrefetchCount { get; private set; }
         public string Username { get; }
@@ -156,6 +158,11 @@ namespace Shuttle.Esb.RabbitMQ
             {
                 Persistent = result;
             }
+        }
+
+        private void SetName(QueryString parameters)
+        {
+            Name = parameters["name"];
         }
     }
 }


### PR DESCRIPTION
…llow garbage collect the channels on every thread when connection is closed. Also remove the dead thread channels from the instance list when a new channel is created.

Dispose was called from AccessQueue methods, so the lock is needed, added a new CloseConnection method and calling it from AccessQueue and from Dispose

using nameof expressions

allow to specify the queue name(it is shown in the Rabbit web UI Connections page)