### PR TITLE
Use backgroud threads

### DIFF
--- a/Shuttle.Esb.RabbitMQ/RabbitMQQueue.cs
+++ b/Shuttle.Esb.RabbitMQ/RabbitMQQueue.cs
@@ -59,7 +59,8 @@ namespace Shuttle.Esb.RabbitMQ
                 HostName = _parser.Host,
                 VirtualHost = _parser.VirtualHost,
                 Port = _parser.Port,
-                RequestedHeartbeat = configuration.RequestedHeartbeat
+                RequestedHeartbeat = configuration.RequestedHeartbeat,
+                UseBackgroundThreadsForIO = true
             };
         }
 


### PR DESCRIPTION
Shuttle is using backgound threads, but RabbitMQ is creating some non background threads by default. It needs to be set to true explicitly.