### PR TITLE
Do not reopen Channel after Queue is disposed.

### DIFF
--- a/Shuttle.Esb.RabbitMQ/RabbitMQQueue.cs
+++ b/Shuttle.Esb.RabbitMQ/RabbitMQQueue.cs
@@ -28,6 +28,7 @@ namespace Shuttle.Esb.RabbitMQ
 
         private readonly RabbitMQUriParser _parser;
         private volatile IConnection _connection;
+        private bool _disposed;
 
         public RabbitMQQueue(Uri uri, IRabbitMQConfiguration configuration)
         {
@@ -75,6 +76,7 @@ namespace Shuttle.Esb.RabbitMQ
         public void Dispose()
         {
             CloseConnection();
+            _disposed = true;
         }
 
         private void CloseConnection()
@@ -340,6 +342,11 @@ namespace Shuttle.Esb.RabbitMQ
 
         private void AccessQueue(Action action, int retry = 0)
         {
+            if (_disposed)
+            {
+                return;
+            }
+
             try
             {
                 action.Invoke();


### PR DESCRIPTION
A late called Acknowledge is reopening a Channel, which is causing that a Channel object remains open since the Queue is disposed and GCd, so no reference will be for the Channel object inside Shuttle, but RabbitMQ client is keeping that in a dictionary an in an event handler.

![image](https://user-images.githubusercontent.com/3104253/87701423-41bbbb00-c798-11ea-990b-fe4046fb0c79.png)
