### PR TITLE
use cached memorystreams

### DIFF
--- a/Shuttle.Esb.RabbitMQ/MemoryStreamCache.cs
+++ b/Shuttle.Esb.RabbitMQ/MemoryStreamCache.cs
@@ -1,0 +1,11 @@
+#if NETSTANDARD2_1
+using Microsoft.IO;
+
+namespace Shuttle.Esb.RabbitMQ
+{
+    internal static class MemoryStreamCache
+    {
+        public static readonly RecyclableMemoryStreamManager Manager = new RecyclableMemoryStreamManager();
+    }
+}
+#endif

--- a/Shuttle.Esb.RabbitMQ/Shuttle.ESB.RabbitMQ.csproj
+++ b/Shuttle.Esb.RabbitMQ/Shuttle.ESB.RabbitMQ.csproj
@@ -17,8 +17,12 @@
     <PackageReference Include="RabbitMQ.Client" Version="6.2.1" />
     <PackageReference Include="Shuttle.Core.Container" Version="11.2.3" />
     <PackageReference Include="Shuttle.Core.Uris" Version="10.0.5" />
-    <PackageReference Include="Shuttle.Esb" Version="11.1.0" />
+    <PackageReference Include="Shuttle.Esb" Version="11.2.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Using the Microsoft.IO.RecyclableMemoryStream package (which is already used by other Shuttle packages) to avoid creation of MemoryStream objects.
This change is only for the netstandard2.1 version, since the netstandard2.0 version of the Stream object has no method for writing a (ReadOnly)Span<byte> to a stream. So it would need an extra copy to a temporary buffer, which probably not worth to avoid the MemoryStream allocation. 